### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ the [project page][project page] if you are interested in creation a dataset for
 Start the front end with a single command (adjust the `/PATH/TO/OUTPUT` to your desired output path)
 
 ```shell
-docker run -it --rm --name easy_image_scraping --network host --mount type=bind,source=/PATH/TO/OUTPUT,target=/usr/src/app/output -p 5000:5000 ghcr.io/a-nau/easy-image-scraping:latest
+docker run -it --rm --name easy_image_scraping --network host --mount type=bind,source=/PATH/TO/OUTPUT,target=/usr/src/app/output ghcr.io/a-nau/easy-image-scraping:latest
 ```
 
 Enter your query and wait for the results to show in the `output` folder. The web applications also shows a preview of


### PR DESCRIPTION
You're using the `--network host` option. This configuration makes the container share the network stack with the host machine, effectively binding all container ports directly to the corresponding host ports. In this case, you're still publishing port 5000 from the container to port 5000 on the host machine using `-p 5000:5000`, but it's unnecessary when using `--network host`. It caused an incorrect binding for me.